### PR TITLE
Cleaned up Android example

### DIFF
--- a/example/AndroidOnlyExample/app/src/main/java/de/jensklingenberg/androidonlyexample/Person.kt
+++ b/example/AndroidOnlyExample/app/src/main/java/de/jensklingenberg/androidonlyexample/Person.kt
@@ -1,0 +1,18 @@
+package de.jensklingenberg.androidonlyexample
+
+@kotlinx.serialization.Serializable
+data class Person(
+    val films: List<String?>? = null,
+    val homeworld: String? = null,
+    val gender: String? = null,
+    val skinColor: String? = null,
+    val edited: String? = null,
+    val created: String? = null,
+    val mass: String? = null,
+    val url: String? = null,
+    val hairColor: String? = null,
+    val birthYear: String? = null,
+    val eyeColor: String? = null,
+    val name: String? = null,
+    val height: String? = null
+)

--- a/example/AndroidOnlyExample/app/src/main/java/de/jensklingenberg/androidonlyexample/StarWarsApi.kt
+++ b/example/AndroidOnlyExample/app/src/main/java/de/jensklingenberg/androidonlyexample/StarWarsApi.kt
@@ -1,0 +1,14 @@
+package de.jensklingenberg.androidonlyexample
+
+interface StarWarsApi {
+
+    @GET("people/{id}/")
+    suspend fun getPerson(@Path("id") personId: Int): Person
+
+    @GET("people")
+    fun getPeople(@Query("page") page: Int): List<Person>
+
+    @GET("people")
+    fun getPeopleFlow(@Query("page") page: Int): Flow<Person>
+
+}


### PR DESCRIPTION
Removed unused code from the Android example, made naming a bit clearer, and added demos of @Path, @Query, Flow response types, and Json parsing.

Since most initial interest will be from Android devs and many will look at the examples first, I think these changes could be helpful in increasing early adopters.