### PR TITLE
Use httpClient builder with engine factory

### DIFF
--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
@@ -60,6 +60,13 @@ class Ktorfit private constructor(
         }
 
         /**
+         * Build HttpClient by just passing an engine factory
+         */
+        fun httpClient(engineFactory: HttpClientEngineFactory<HttpClientEngineConfig>) = apply {
+            this._httpClient = HttpClient(engineFactory)
+        }
+
+        /**
          * Client-Builder that will be used for every request with object
          */
         fun httpClient(config: HttpClientConfig<*>.() -> Unit) = apply {
@@ -71,6 +78,13 @@ class Ktorfit private constructor(
          */
         fun httpClient(engine: HttpClientEngine, config: HttpClientConfig<*>.() -> Unit) = apply {
             this._httpClient = HttpClient(engine, config)
+        }
+
+        /**
+         * Client-Builder with engine factory that will be used for every request with object
+         */
+        fun httpClient(engineFactory: HttpClientEngineFactory<HttpClientEngineConfig>, config: HttpClientConfig<HttpClientEngineConfig>.() -> Unit) = apply {
+            this._httpClient = HttpClient(engineFactory, config)
         }
 
         /**

--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
@@ -62,7 +62,7 @@ class Ktorfit private constructor(
         /**
          * Build HttpClient by just passing an engine factory
          */
-        fun httpClient(engineFactory: HttpClientEngineFactory<HttpClientEngineConfig>) = apply {
+        fun <T : HttpClientEngineConfig> httpClient(engineFactory: HttpClientEngineFactory<T>) = apply {
             this._httpClient = HttpClient(engineFactory)
         }
 
@@ -83,7 +83,7 @@ class Ktorfit private constructor(
         /**
          * Client-Builder with engine factory that will be used for every request with object
          */
-        fun httpClient(engineFactory: HttpClientEngineFactory<HttpClientEngineConfig>, config: HttpClientConfig<HttpClientEngineConfig>.() -> Unit) = apply {
+        fun <T : HttpClientEngineConfig> httpClient(engineFactory: HttpClientEngineFactory<T>, config: HttpClientConfig<T>.() -> Unit) = apply {
             this._httpClient = HttpClient(engineFactory, config)
         }
 

--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/TypeInfoExt.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/TypeInfoExt.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
  */
 fun TypeInfo.upperBoundType(): TypeInfo? {
     val parentType = this.kotlinType ?: return null
-    val modelKTypeProjection = if (parentType.arguments.size >= 0) parentType.arguments[0] else return null
+    val modelKTypeProjection = if (parentType.arguments.isNotEmpty()) parentType.arguments[0] else return null
     val modelKType = modelKTypeProjection.type ?: return null
     val modelClass = (modelKType.classifier as? KClass<*>?) ?: return null
     return TypeInfo(modelClass, modelKType.platformType, modelKType)


### PR DESCRIPTION
This adds compatibility to use the Engine factory directly like this (JVM example):
```kotlin
val client = ktorfit {
    baseUrl("example.com")
    httpClient(CIO) {
        install(ContentNegotiation)
    }
}
```

Previous:
```kotlin
val client = ktorfit {
    baseUrl("example.com")
    httpClient(CIO.create()) {
        install(ContentNegotiation)
    }
}
```