### PR TITLE
Added RequestConverter support

### DIFF
--- a/ktorfit-annotations/src/commonMain/kotlin/de/jensklingenberg/ktorfit/http/RequestType.kt
+++ b/ktorfit-annotations/src/commonMain/kotlin/de/jensklingenberg/ktorfit/http/RequestType.kt
@@ -1,0 +1,6 @@
+package de.jensklingenberg.ktorfit.http
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class RequestType(val requestType: KClass<*>)

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/ParameterData.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/ParameterData.kt
@@ -2,15 +2,18 @@ package de.jensklingenberg.ktorfit.model
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ClassName
 import de.jensklingenberg.ktorfit.model.annotations.ParameterAnnotation
 import de.jensklingenberg.ktorfit.model.annotations.getParamAnnotationList
 import de.jensklingenberg.ktorfit.utils.getRequestBuilderAnnotation
+import de.jensklingenberg.ktorfit.utils.getRequestTypeAnnotations
 import de.jensklingenberg.ktorfit.utils.resolveTypeName
 
 data class ParameterData(
     val name: String,
     val type: ReturnTypeData,
     val annotations: List<ParameterAnnotation> = emptyList(),
+    val requestTypeClassName: ClassName? = null,
     val hasRequestBuilderAnno: Boolean = false
 ) {
     inline fun <reified T> findAnnotationOrNull(): T? {
@@ -19,6 +22,10 @@ data class ParameterData(
 
     inline fun <reified T> hasAnnotation(): Boolean {
         return this.findAnnotationOrNull<T>() != null
+    }
+
+    fun hasRequestTypeAnnotation(): Boolean {
+        return this.requestTypeClassName != null
     }
 }
 
@@ -29,6 +36,7 @@ fun KSValueParameter.createParameterData(logger: KSPLogger): ParameterData {
     }
 
     val parameterAnnotations = ksValueParameter.getParamAnnotationList( logger)
+    val requestTypeAnnotationClassName = ksValueParameter.getRequestTypeAnnotations()
 
     val reqBuilderAnno = ksValueParameter.getRequestBuilderAnnotation()
     val parameterName = ksValueParameter.name?.asString() ?: ""
@@ -61,6 +69,12 @@ fun KSValueParameter.createParameterData(logger: KSPLogger): ParameterData {
         )
     }
 
-    return ParameterData(parameterName, type, parameterAnnotations, hasRequestBuilderAnno)
+    return ParameterData(
+        parameterName,
+        type,
+        parameterAnnotations,
+        requestTypeAnnotationClassName,
+        hasRequestBuilderAnno
+    )
 
 }

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/requestData/RequestConverterText.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/requestData/RequestConverterText.kt
@@ -1,0 +1,21 @@
+package de.jensklingenberg.ktorfit.requestData
+
+import com.squareup.kotlinpoet.FunSpec
+import de.jensklingenberg.ktorfit.model.FunctionData
+
+fun FunSpec.Builder.addRequestConverterText(functionData: FunctionData) = apply {
+    val parameterNames = functionData.parameterDataList.map { parameter ->
+        val parameterNameUpperCase = parameter.name.replaceFirstChar { parameter.name.first().titlecaseChar() }
+        if (parameter.hasRequestTypeAnnotation()) {
+            this.addStatement("val requestKClass$parameterNameUpperCase = %T::class", parameter.requestTypeClassName!!)
+            this.addStatement("val requestConverter$parameterNameUpperCase = client.ktorfit.requestConverters.firstOrNull {")
+            this.addStatement("\tit.supportedType(${parameter.name}::class, requestKClass$parameterNameUpperCase)")
+            this.addStatement("} ?: throw IllegalArgumentException(%S)", "No RequestConverter found for parameter '${parameter.name}' in method '${functionData.name}'")
+            this.addStatement("val convertedType$parameterNameUpperCase: %T = requestKClass$parameterNameUpperCase.cast(requestConverter$parameterNameUpperCase.convert(${parameter.name}))\n", parameter.requestTypeClassName)
+            "convertedType$parameterNameUpperCase"
+        } else {
+            parameter.name
+        }
+    }
+    this.addStatement("return ${functionData.name}(${parameterNames.joinToString()})")
+}

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/utils/KSValueParameterExt.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/utils/KSValueParameterExt.kt
@@ -2,7 +2,11 @@ package de.jensklingenberg.ktorfit.utils
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ksp.toClassName
 import de.jensklingenberg.ktorfit.model.annotations.*
 
 @OptIn(KspExperimental::class)
@@ -98,4 +102,17 @@ fun KSValueParameter.getBodyAnnotation(): Body? {
     return this.getAnnotationsByType(de.jensklingenberg.ktorfit.http.Body::class).firstOrNull()?.let {
         return Body()
     }
+}
+
+fun KSAnnotated.getRequestTypeAnnotations(): ClassName? {
+    val requestTypeClazz = de.jensklingenberg.ktorfit.http.RequestType::class
+    val filteredAnnotations = this.annotations.filter {
+        it.shortName.getShortName() == requestTypeClazz.simpleName
+                && it.annotationType.resolve().declaration.qualifiedName?.asString() == requestTypeClazz.qualifiedName
+    }
+    return filteredAnnotations.mapNotNull {
+        it.arguments.map { arg ->
+            (arg.value as KSType).toClassName()
+        }.firstOrNull()
+    }.firstOrNull()
 }

--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt
@@ -3,6 +3,7 @@ package de.jensklingenberg.ktorfit
 import de.jensklingenberg.ktorfit.Strings.Companion.EXPECTED_URL_SCHEME
 import de.jensklingenberg.ktorfit.converter.SuspendResponseConverter
 import de.jensklingenberg.ktorfit.converter.request.CoreResponseConverter
+import de.jensklingenberg.ktorfit.converter.request.RequestConverter
 import de.jensklingenberg.ktorfit.converter.request.ResponseConverter
 import io.ktor.client.*
 import io.ktor.client.engine.*
@@ -14,8 +15,9 @@ import io.ktor.client.engine.*
 class Ktorfit private constructor(
     val baseUrl: String,
     val httpClient: HttpClient = HttpClient(),
-    val requestConverters: Set<ResponseConverter>,
+    val responseConverters: Set<ResponseConverter>,
     val suspendResponseConverters: Set<SuspendResponseConverter>,
+    val requestConverters: Set<RequestConverter>
 ) {
 
     /**
@@ -29,6 +31,7 @@ class Ktorfit private constructor(
         private var _httpClient = HttpClient()
         private var _responseConverter: MutableSet<ResponseConverter> = mutableSetOf()
         private var _suspendResponseConverter: MutableSet<SuspendResponseConverter> = mutableSetOf()
+        private var _requestConverter: MutableSet<RequestConverter> = mutableSetOf()
 
         /**
          * That will be used for every request with object
@@ -106,6 +109,10 @@ class Ktorfit private constructor(
             }
         }
 
+        fun requestConverter(vararg converters: RequestConverter) = apply {
+            this._requestConverter.addAll(converters)
+        }
+
 
         /**
          * Apply changes to builder and get the Ktorfit instance without the need of calling [build] afterwards.
@@ -116,7 +123,7 @@ class Ktorfit private constructor(
          * Creates an instance of Ktorfit with specified baseUrl and HttpClient.
          */
         fun build(): Ktorfit {
-            return Ktorfit(_baseUrl, _httpClient, _responseConverter, _suspendResponseConverter)
+            return Ktorfit(_baseUrl, _httpClient, _responseConverter, _suspendResponseConverter, _requestConverter)
         }
     }
 }

--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/converter/request/RequestConverter.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/converter/request/RequestConverter.kt
@@ -1,0 +1,10 @@
+package de.jensklingenberg.ktorfit.converter.request
+
+import kotlin.reflect.KClass
+
+interface RequestConverter {
+
+    fun supportedType(parameterType: KClass<*>, requestType: KClass<*>): Boolean
+
+    fun convert(data: Any): Any
+}

--- a/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/internal/KtorfitClient.kt
+++ b/ktorfit-lib/src/commonMain/kotlin/de/jensklingenberg/ktorfit/internal/KtorfitClient.kt
@@ -35,7 +35,7 @@ class KtorfitClient(val ktorfit: Ktorfit) {
         requestData: RequestData
     ): ReturnType? {
 
-        ktorfit.requestConverters.firstOrNull { converter ->
+        ktorfit.responseConverters.firstOrNull { converter ->
             converter.supportedType(
                 requestData.returnTypeData, false
             )

--- a/sandbox/src/commonMain/kotlin/com/example/api/JsonPlaceHolderApi.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/api/JsonPlaceHolderApi.kt
@@ -38,7 +38,7 @@ interface JsonPlaceHolderApi {
     suspend fun getCommentsByPostId(@Path("postId") postId: Int): List<Comment>?
 
     @GET("posts/{postId}/comments")
-    suspend fun getCommentsByPostIdResponse(@Path("postId") postId: Int): MyOwnResponse<List<Comment>>
+    suspend fun getCommentsByPostIdResponse(@RequestType(Int::class) @Path("postId") postId: String): MyOwnResponse<List<Comment>>
 
     @Headers(value = ["Content-Type: application/json"])
     @GET("posts/{postId}/comments")

--- a/sandbox/src/commonMain/kotlin/com/example/model/StringToIntRequestConverter.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/model/StringToIntRequestConverter.kt
@@ -1,0 +1,16 @@
+package com.example.model
+
+import de.jensklingenberg.ktorfit.converter.request.RequestConverter
+import kotlin.reflect.KClass
+
+class StringToIntRequestConverter : RequestConverter {
+    override fun supportedType(parameterType: KClass<*>, requestType: KClass<*>): Boolean {
+        val parameterIsString = parameterType == String::class
+        val requestIsInt = requestType == Int::class
+        return parameterIsString && requestIsInt
+    }
+
+    override fun convert(data: Any): Any {
+        return (data as String).toInt()
+    }
+}

--- a/sandbox/src/jvmMain/kotlin/de/jensklingenberg/ktorfit/demo/JvMMain.kt
+++ b/sandbox/src/jvmMain/kotlin/de/jensklingenberg/ktorfit/demo/JvMMain.kt
@@ -4,6 +4,7 @@ package de.jensklingenberg.ktorfit.demo
 import com.example.api.JsonPlaceHolderApi
 import com.example.model.MyOwnResponse
 import com.example.model.MyOwnResponseConverter
+import com.example.model.StringToIntRequestConverter
 import de.jensklingenberg.ktorfit.converter.builtin.CallResponseConverter
 import de.jensklingenberg.ktorfit.converter.builtin.FlowResponseConverter
 import de.jensklingenberg.ktorfit.create
@@ -43,6 +44,9 @@ val jvmKtorfit = ktorfit {
         CallResponseConverter(),
         MyOwnResponseConverter()
     )
+    requestConverter(
+        StringToIntRequestConverter()
+    )
 }
 
 
@@ -54,7 +58,7 @@ fun main() {
         val api = jvmKtorfit.create<JsonPlaceHolderApi>()
 
 
-        val test = api.getCommentsByPostIdResponse(3)
+        val test = api.getCommentsByPostIdResponse("3")
 
         when (test) {
             is MyOwnResponse.Success -> {


### PR DESCRIPTION
Quickly learned it :) fixes #82

## Could not use `ParameterAnnotation`

This Annotation is handled separatly as KSP can't handle `KClass<*>`, see: https://github.com/google/ksp/issues/1129 and it's referenced issue.

However everything else is implemented the way it's described in my issue