### PR TITLE
Add `foojay-resolver-convention` plugin to `settings.gradle.kts`

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,9 @@ pluginManagement {
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
 
 rootProject.name = "Ktorfit"
 include(":ktorfit-gradle-plugin")


### PR DESCRIPTION
### :thinking: DOD Checklist

- [x] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).

---

After cloning this repository, any Gradle command ran into errors caused by a missing toolchain:
> Caused by: org.gradle.jvm.toolchain.internal.ToolchainDownloadFailedException: No locally installed toolchains match and toolchain download repositories have not been configured.

This can be solved by including https://github.com/gradle/foojay-toolchains into our `settings.gradle.kts`.