### PR TITLE
Response returns NullBody instead of null for StatusCode 204 and 205

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project orients towards [Semantic Versioning](http://semver.org/spec/v2
 Note: This project needs KSP to work and every new Ktorfit with an update of the KSP version is technically a breaking change.
 But there is no intent to bump the Ktorfit major version for every KSP update. 
 
+### Changed
+- Response returns NullBody instead of null for StatusCode 204 and 205
+
 1.12.0 - 2024-01-16
 ========================================
 - Compatible with KSP 1.0.16 and Kotlin 1.9.22

--- a/ktorfit-lib-core/src/commonMain/kotlin/de/jensklingenberg/ktorfit/converter/builtin/DefaultResponseClassSuspendConverter.kt
+++ b/ktorfit-lib-core/src/commonMain/kotlin/de/jensklingenberg/ktorfit/converter/builtin/DefaultResponseClassSuspendConverter.kt
@@ -7,6 +7,7 @@ import de.jensklingenberg.ktorfit.converter.KtorfitResult
 import de.jensklingenberg.ktorfit.internal.TypeData
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
+import io.ktor.http.content.NullBody
 
 internal class DefaultResponseClassSuspendConverter(private val typeData: TypeData, private val ktorfit: Ktorfit) :
     Converter.SuspendResponseConverter<HttpResponse, Response<Any?>> {
@@ -27,7 +28,7 @@ internal class DefaultResponseClassSuspendConverter(private val typeData: TypeDa
                     }
 
                     code == 204 || code == 205 -> {
-                        Response.success(null, rawResponse)
+                        Response.success(NullBody, rawResponse)
                     }
 
                     else -> {


### PR DESCRIPTION
### :thinking: DOD Checklist

Response returns NullBody instead of null for StatusCode 204 and 205.
NullBody is an object from Ktor that was created for exactly such a purpose.
https://api.ktor.io/ktor-http/io.ktor.http.content/-null-body/index.html

It is now possible to use:
@DELETE("...")
fun test(...): Response< NullBody >

Alternatively, it would be possible to delete the additional check (code == 204 || code == 205) and simply use the standard conversion. Then a Response< Unit > could also be possible. Feedback would be appreciated.

- [X] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
