### PR TITLE
Fix sample code for SuspendResponseConverter

### DIFF
--- a/docs/converters/suspendresponseconverter.md
+++ b/docs/converters/suspendresponseconverter.md
@@ -33,11 +33,15 @@ class MyOwnResponseConverterFactory : Converter.Factory{
         if(typeData.typeInfo.type == MyOwnResponse::class) {
            
             return object : Converter.SuspendResponseConverter<HttpResponse, Any> {
-                override suspend fun convert(response: HttpResponse): Any {
-                    return try {
-                        MyOwnResponse.success(response.body(typeData.typeArgs.first().typeInfo))
-                    } catch (ex: Throwable) {
-                        MyOwnResponse.error(ex)
+                override suspend fun convert(result: KtorfitResult): Any {
+                    return when (result) {
+                        is KtorfitResult.Failure -> {
+                            MyOwnResponse.error(result.throwable)
+                        }
+
+                        is KtorfitResult.Success -> {
+                            MyOwnResponse.success(result.response.body(typeData.typeArgs.first().typeInfo))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously, implementing SuspendResponseConverter had a function `convert(response: HttpResponse)` that it is now changed to the `convert(result: KtorfitResult)`; So the document must be updated.
