### PR TITLE
Point proguard file to an absolute link in doc

### DIFF
--- a/docs/android/proguard.md
+++ b/docs/android/proguard.md
@@ -1,4 +1,4 @@
 If you use Ktorfit as a dependency in an Android project which uses R8 as a default compiler you don’t have to 
 do anything. The specific rules are 
-[already bundled](../../ktorfit-lib-core/src/jvmMain/resources/META-INF/proguard/ktorfit.pro) into the JAR 
+[already bundled](https://github.com/Foso/Ktorfit/blob/master/ktorfit-lib-core/src/jvmMain/resources/META-INF/proguard/ktorfit.pro) into the JAR 
 which can be interpreted by R8 automatically.


### PR DESCRIPTION
`../../ktorfit-lib-core/src/jvmMain/resources/META-INF/proguard/ktorfit.pro` can't be recognized correctly by MkDocs.

Follow up #834.

### :thinking: DOD Checklist

- [ ] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
