### PR TITLE
Update KSP version check in KtorfitGradlePlugin

### DIFF
--- a/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
+++ b/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
@@ -139,9 +139,14 @@ class KtorfitGradlePlugin : Plugin<Project> {
     }
 
     private fun checkKSPVersion(kspVersion: String) {
-        val kspVersionParts = kspVersion.split(".")
-        if (kspVersionParts[2].toInt() < MIN_KSP_VERSION.split(".")[2].toInt()) {
-            error("Ktorfit: KSP version $kspVersion is not supported. You need at least version $MIN_KSP_VERSION")
+        val kspParts = kspVersion.split(".").map { it.toInt() }
+        val minParts = MIN_KSP_VERSION.split(".").map { it.toInt() }
+        for (i in 0 until minOf(kspParts.size, minParts.size)) {
+            if (kspParts[i] > minParts[i]) {
+                return
+            } else if (kspParts[i] < minParts[i]) {
+                error("Ktorfit: KSP version $kspVersion is not supported. You need at least version $MIN_KSP_VERSION")
+            }
         }
     }
 }


### PR DESCRIPTION
The KSP version check in the Ktorfit Gradle plugin has been updated to ensure compatibility with KSP versions greater than or equal to 1.0.31. The previous check only compared the third part of the version string, which could lead to incorrect results. The updated check compares each part of the version string to accurately determine if the KSP version meets the minimum requirement.

Fix: #841

### :thinking: DOD Checklist

- [ ] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
