### PR TITLE
Fix annotation array args with annotation elements

### DIFF
--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/reqBuilderExtension/AttributesCodeGenerator.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/reqBuilderExtension/AttributesCodeGenerator.kt
@@ -4,7 +4,6 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import de.jensklingenberg.ktorfit.model.ParameterData
 import de.jensklingenberg.ktorfit.model.annotations.ParameterAnnotation
 import de.jensklingenberg.ktorfit.model.annotationsAttributeKey
-import de.jensklingenberg.ktorfit.utils.toClassName
 
 fun getAttributesCode(
     parameterDataList: List<ParameterData>,
@@ -32,10 +31,7 @@ fun getAttributesCode(
             prefix = "listOf(\n",
             postfix = ",\n)",
         ) { annotation ->
-            annotation
-                .members
-                .joinToString { it.toString() }
-                .let { "${annotation.toClassName().simpleName}($it)" }
+            annotation.toString().trimStart('@')
         }
             .let { "attributes.put(${annotationsAttributeKey.name}, $it)" }
 


### PR DESCRIPTION
Previously, `getAttributesCode()` did not correctly handle annotation instances inside annotation array parameters. For example, given:

```kotlin
annotation class AnnotationC(val s: String)
annotation class AnnotationD(
  val s: Array<AnnotationC>
)
interface API {
  @GET("/")
  @AnnotationD(s = [AnnotationC(s = "foo")])
  fun test()
}
```

Ktorfit would produce an `_APIImpl` class with the following code:

```kotlin
attributes.put(annotationsAttributeKey, listOf(
  AnnotationD(s = arrayOf(@com.example.AnnotationC(s = "foo"))),
))
```

**Note the syntax error:** when an annotation is used as a value (not as an annotation on a declaration), the leading `@` should be omitted.

Actually, in KotlinPoet, this kind of value could be generated by using
```kotlin
AnnotationSpec.emit(..., asParameter = true)
```
or
```kotlin
CodeWriter.emitCode(..., isConstantContext = true)
```
However, none of those APIs are public. :cry:

As a workaround, this patch generates the code for the whole AnnotationSpec and removes the prefixed `@`, which is the simplest solution I can find.

### :thinking: DOD Checklist

- [ ] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
