### PR TITLE
Integration test that fails when a generic return type is used in ios

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,3 +38,9 @@ apiValidation {
         enabled = true
     }
 }
+
+allprojects {
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        dependsOn(":sandbox:allTests")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ detekt = "1.23.8"
 junit = "4.13.2"
 kctfork = "0.8.0"
 kotlin = "2.2.0"
+kotlinx = "1.10.1"
 kotlinPoet = "2.2.0"
 kspVersion = "2.2.0-2.0.2"
 
@@ -44,6 +45,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-serialization-runtime-js = "org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:0.20.0"
 kspApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "kspVersion" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx" }
 
 #Ktor
 ktor-client-cio-jvm = { module = "io.ktor:ktor-client-cio-jvm", version.ref = "ktorVersion" }

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -55,7 +55,6 @@ kotlin {
     applyDefaultHierarchyTemplate()
     sourceSets {
         commonMain {
-
             dependencies {
                 implementation(projects.ktorfitLibCore)
                 implementation(projects.ktorfitConverters.flow)
@@ -65,6 +64,13 @@ kotlin {
                 implementation(libs.ktor.client.serialization)
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlin.coroutines.test)
+                implementation(libs.ktor.client.mock)
             }
         }
         linuxX64Main {

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
     }
     iosX64()
     iosArm64()
+    iosSimulatorArm64()
     js(IR) {
         this.nodejs()
         binaries.executable() // not applicable to BOTH, see details below

--- a/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
@@ -4,6 +4,7 @@ import com.example.model.People
 import de.jensklingenberg.ktorfit.Call
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
+import kotlinx.coroutines.flow.Flow
 
 interface StarWarsApi {
     companion object {
@@ -16,5 +17,5 @@ interface StarWarsApi {
     ): Call<People>
 
     @GET("people/stormtrooper/all")
-    suspend fun summonStormtroopers(): List<People>
+    fun summonStormtroopers(): Flow<List<People>>
 }

--- a/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
@@ -14,4 +14,7 @@ interface StarWarsApi {
     fun getPersonById(
         @Path("id") peopleId: Int
     ): Call<People>
+
+    @GET("people/stormtrooper/all")
+    suspend fun summonStormtroopers(): List<People>
 }

--- a/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/api/StarWarsApi.kt
@@ -17,5 +17,8 @@ interface StarWarsApi {
     ): Call<People>
 
     @GET("people/stormtrooper/all")
-    fun summonStormtroopers(): Flow<List<People>>
+    fun subscribeToStormtroopers(): Flow<List<People>>
+
+    @GET("people/stormtrooper/all")
+    suspend fun summonStormtroopers(): List<People>
 }

--- a/sandbox/src/commonTest/kotlin/com/example/StormtrooperLegionTest.kt
+++ b/sandbox/src/commonTest/kotlin/com/example/StormtrooperLegionTest.kt
@@ -1,0 +1,67 @@
+package com.example
+
+import com.example.api.createStarWarsApi
+import com.example.model.People
+import de.jensklingenberg.ktorfit.Ktorfit
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class StormtrooperLegionTest {
+    @Test
+    fun `Given mocked response When summonStormtroopers Then obtain not null expected result`() = runTest {
+        val stringJsonListStormtroopersContent = """
+                    [
+                        {
+                            "gender": "male"
+                        },
+                        {
+                            "gender": "female"
+                        },
+                        {
+                            "gender": "twilek"
+                        }
+                    ]
+                """.trimIndent()
+        val mockEngine = MockEngine {
+            respond(
+                content = stringJsonListStormtroopersContent,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val starWarsApi = setUpTestKtorfit(mockEngine).createStarWarsApi()
+
+        val result = starWarsApi.summonStormtroopers()
+        assertNotNull(result)
+        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result)
+    }
+}
+
+private fun setUpTestKtorfit(engine: HttpClientEngine): Ktorfit {
+    val httpClient = HttpClient(engine) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    prettyPrint = true
+                    isLenient = true
+                }
+            )
+        }
+    }
+    return Ktorfit.Builder()
+//        .converterFactories(ResponseConverterFactory())
+        .httpClient(httpClient)
+        .build()
+}

--- a/sandbox/src/commonTest/kotlin/com/example/SummonStormtroopersTest.kt
+++ b/sandbox/src/commonTest/kotlin/com/example/SummonStormtroopersTest.kt
@@ -22,6 +22,39 @@ import kotlin.test.assertNotNull
 
 class SummonStormtroopersTest {
     @Test
+    fun `Given mocked response When subscribeToStormtroopers Then obtain not null expected result`() = runTest {
+        // Given
+        val stringJsonListStormtroopersContent = """
+                    [
+                        {
+                            "gender": "male"
+                        },
+                        {
+                            "gender": "female"
+                        },
+                        {
+                            "gender": "twilek"
+                        }
+                    ]
+                """.trimIndent()
+        val mockEngine = MockEngine {
+            respond(
+                content = stringJsonListStormtroopersContent,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val starWarsApi = setUpTestKtorfit(mockEngine).createStarWarsApi()
+
+        // When
+        val result = starWarsApi.subscribeToStormtroopers()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result.first())
+    }
+
+    @Test
     fun `Given mocked response When summonStormtroopers Then obtain not null expected result`() = runTest {
         // Given
         val stringJsonListStormtroopersContent = """
@@ -51,7 +84,7 @@ class SummonStormtroopersTest {
 
         // Then
         assertNotNull(result)
-        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result.first())
+        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result)
     }
 }
 

--- a/sandbox/src/commonTest/kotlin/com/example/SummonStormtroopersTest.kt
+++ b/sandbox/src/commonTest/kotlin/com/example/SummonStormtroopersTest.kt
@@ -3,6 +3,7 @@ package com.example
 import com.example.api.createStarWarsApi
 import com.example.model.People
 import de.jensklingenberg.ktorfit.Ktorfit
+import de.jensklingenberg.ktorfit.converter.FlowConverterFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.mock.MockEngine
@@ -12,15 +13,17 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-class StormtrooperLegionTest {
+class SummonStormtroopersTest {
     @Test
     fun `Given mocked response When summonStormtroopers Then obtain not null expected result`() = runTest {
+        // Given
         val stringJsonListStormtroopersContent = """
                     [
                         {
@@ -43,9 +46,12 @@ class StormtrooperLegionTest {
         }
         val starWarsApi = setUpTestKtorfit(mockEngine).createStarWarsApi()
 
+        // When
         val result = starWarsApi.summonStormtroopers()
+
+        // Then
         assertNotNull(result)
-        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result)
+        assertEquals(Json.decodeFromString<List<People>>(stringJsonListStormtroopersContent), result.first())
     }
 }
 
@@ -61,7 +67,7 @@ private fun setUpTestKtorfit(engine: HttpClientEngine): Ktorfit {
         }
     }
     return Ktorfit.Builder()
-//        .converterFactories(ResponseConverterFactory())
+        .converterFactories(FlowConverterFactory())
         .httpClient(httpClient)
         .build()
 }


### PR DESCRIPTION
### :thinking: DOD Checklist

- [ ] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).

Following the discussion from here https://github.com/Foso/Ktorfit/issues/887#issuecomment-3069491050
Added a unit test that is executed before each maven publishing task.
The test will fail when Flow convertor is not working. Right now it is failing on ios.
Note: there is one more test that works because it is running with `DefaultSuspendedResponseConverterFactory`, maybe the bug is in another converter factories