### PR TITLE
Add don't override a method with NoDelegation and have body

### DIFF
--- a/ktorfit-annotations/src/commonMain/kotlin/de/jensklingenberg/ktorfit/core/NoDelegation.kt
+++ b/ktorfit-annotations/src/commonMain/kotlin/de/jensklingenberg/ktorfit/core/NoDelegation.kt
@@ -7,5 +7,5 @@ package de.jensklingenberg.ktorfit.core
  * Kotlin delegation for this interface. This is useful when you want to manually implement the
  * methods of the interface or when delegation is not desired for other reasons.
  */
-@Target(AnnotationTarget.TYPE)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
 annotation class NoDelegation

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/KtorfitError.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/KtorfitError.kt
@@ -52,5 +52,7 @@ internal class KtorfitError {
         fun noHttpAnnotationAt(functionName: String) = "No Http annotation at $functionName"
 
         fun urlCanOnlyBeUsedWithEmpty(keyword: String) = "@Url can only be used with empty @$keyword URL value"
+
+        fun noDefaultImplWithNoDelegation(functionName: String) = "@NoDelegation annotation requires a default implementation on $functionName"
     }
 }

--- a/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/NoDelegationMethodTest.kt
+++ b/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/NoDelegationMethodTest.kt
@@ -1,0 +1,80 @@
+package de.jensklingenberg.ktorfit
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspSourcesDir
+import de.jensklingenberg.ktorfit.model.KtorfitError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class NoDelegationMethodTest {
+    @Test
+    fun `When function is annotated with NoDelegation is skipped of generated code`() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """
+                package test
+
+                import de.jensklingenberg.ktorfit.http.GET
+                import de.jensklingenberg.ktorfit.core.NoDelegation
+                import kotlinx.coroutines.runBlocking
+
+                interface TestService {
+                    @GET("/hello")
+                    suspend fun test(): String
+
+                    @GET("/hello/world")
+                    @NoDelegation
+                    fun test2(): String = runBlocking { test() }
+                }
+                """
+            )
+
+        val noExpectedOverrideMethod = """override fun test2()"""
+
+        val compilation = getCompilation(listOf(source))
+        val result = compilation.compile()
+
+        assertFalse(result.messages.contains(KtorfitError.noDefaultImplWithNoDelegation("test2")))
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/test/_TestServiceImpl.kt",
+            )
+        val actualSource = generatedFile.readText()
+        assertFalse(actualSource.contains(noExpectedOverrideMethod))
+    }
+
+    @Test
+    fun `When function is annotated with NoDelegation and don't have body, throw error`() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """
+                package test
+
+                import de.jensklingenberg.ktorfit.http.GET
+                import de.jensklingenberg.ktorfit.core.NoDelegation
+
+                interface TestService {
+                    @GET("/hello")
+                    suspend fun test(): String
+
+                    @GET("/hello/world")
+                    @NoDelegation
+                    fun test2(): String
+                }
+                """
+            )
+
+        val compilation = getCompilation(listOf(source))
+        val result = compilation.compile()
+        assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        assertTrue(result.messages.contains(KtorfitError.noDefaultImplWithNoDelegation("test2")))
+    }
+}


### PR DESCRIPTION
Hey, this is a preview to resolve https://github.com/Foso/Ktorfit/issues/868 This is the cleanest version, but need to be tested when use inheritance, or other use cases. 

Is very simple, add target function to `@NoDelegation`

```kotlin
interface TestService {
    @GET("/hello")
    suspend fun test(): String

    @GET("/hello/world") // is not necessary, but can have it
    @NoDelegation // without this is error
    fun test2(): String = runBlocking { test() }
}
```
Before this PR, ktorfit override all functions of the interface and/or throw error when don't have http annotations.

### :thinking: DOD Checklist
_Need review, after that, can add to docs_
- [ ] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
