### PR TITLE
Add typealias support to KSP processor

### DIFF
--- a/ktorfit-ksp/api/ktorfit-ksp.api
+++ b/ktorfit-ksp/api/ktorfit-ksp.api
@@ -492,6 +492,7 @@ public final class de/jensklingenberg/ktorfit/utils/UtilsKt {
 	public static final fun postfixIfNotEmpty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun prefixIfNotEmpty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun removeWhiteSpaces (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun resolveTypeAlias (Lcom/google/devtools/ksp/symbol/KSType;)Lcom/google/devtools/ksp/symbol/KSType;
 	public static final fun resolveTypeName (Lcom/google/devtools/ksp/symbol/KSType;)Ljava/lang/String;
 	public static final fun safeString (Lcom/google/devtools/ksp/symbol/KSName;)Ljava/lang/String;
 	public static final fun surroundIfNotEmpty (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/annotations/ParameterAnnotation.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/annotations/ParameterAnnotation.kt
@@ -19,6 +19,7 @@ import de.jensklingenberg.ktorfit.utils.getRequestBuilderAnnotation
 import de.jensklingenberg.ktorfit.utils.getRequestTypeAnnotation
 import de.jensklingenberg.ktorfit.utils.getTagAnnotation
 import de.jensklingenberg.ktorfit.utils.getUrlAnnotation
+import de.jensklingenberg.ktorfit.utils.resolveTypeAlias
 
 /**
  * Annotation at a parameter
@@ -128,14 +129,11 @@ fun KSValueParameter.getParamAnnotationList(logger: KSPLogger): List<ParameterAn
 
     ksValueParameter.getHeaderMapAnnotation()?.let {
         // TODO: Find out how isAssignableFrom works
-        if (!ksValueParameter.type.toString().substringBefore("<").endsWith(KEY_MAP)) {
+        val resolvedType = ksValueParameter.type.resolve().resolveTypeAlias()
+        if (!resolvedType.toString().substringBefore("<").endsWith(KEY_MAP)) {
             logger.error(KtorfitError.HEADER_MAP_PARAMETER_TYPE_MUST_BE_MAP, ksValueParameter)
         }
-        val mapKey =
-            ksValueParameter.type
-                .resolve()
-                .arguments
-                .first()
+        val mapKey = resolvedType.arguments.first()
         if (mapKey.type.toString() != KEY_STRING || mapKey.type?.resolve()?.isMarkedNullable == true) {
             logger.error(KtorfitError.HEADER_MAP_KEYS_MUST_BE_OF_TYPE_STRING, ksValueParameter)
         }
@@ -143,15 +141,12 @@ fun KSValueParameter.getParamAnnotationList(logger: KSPLogger): List<ParameterAn
     }
 
     ksValueParameter.getQueryMapAnnotation()?.let {
-        if (!ksValueParameter.type.toString().substringBefore("<").endsWith(KEY_MAP)) {
+        val resolvedType = ksValueParameter.type.resolve().resolveTypeAlias()
+        if (!resolvedType.toString().substringBefore("<").endsWith(KEY_MAP)) {
             logger.error(KtorfitError.QUERY_MAP_PARAMETER_TYPE_MUST_BE_MAP, ksValueParameter)
         }
 
-        val mapKey =
-            ksValueParameter.type
-                .resolve()
-                .arguments
-                .first()
+        val mapKey = resolvedType.arguments.first()
         if (mapKey.type.toString() != KEY_STRING || mapKey.type?.resolve()?.isMarkedNullable == true) {
             logger.error(KtorfitError.QUERY_MAP_KEYS_MUST_BE_OF_TYPE_STRING, ksValueParameter)
         }
@@ -159,15 +154,12 @@ fun KSValueParameter.getParamAnnotationList(logger: KSPLogger): List<ParameterAn
     }
 
     ksValueParameter.getFieldMapAnnotation()?.let {
-        if (!ksValueParameter.type.toString().substringBefore("<").endsWith(KEY_MAP)) {
+        val resolvedType = ksValueParameter.type.resolve().resolveTypeAlias()
+        if (!resolvedType.toString().substringBefore("<").endsWith(KEY_MAP)) {
             logger.error(KtorfitError.FIELD_MAP_PARAMETER_TYPE_MUST_BE_MAP, ksValueParameter)
         }
 
-        val mapKey =
-            ksValueParameter.type
-                .resolve()
-                .arguments
-                .first()
+        val mapKey = resolvedType.arguments.first()
         if (mapKey.type.toString() != KEY_STRING || mapKey.type?.resolve()?.isMarkedNullable == true) {
             logger.error(KtorfitError.FIELD_MAP_KEYS_MUST_BE_OF_TYPE_STRING, ksValueParameter)
         }
@@ -182,7 +174,8 @@ fun KSValueParameter.getParamAnnotationList(logger: KSPLogger): List<ParameterAn
     }
 
     ksValueParameter.getPartMapAnnotation()?.let {
-        if (!ksValueParameter.type.toString().substringBefore("<").endsWith(KEY_MAP)) {
+        val resolvedType = ksValueParameter.type.resolve().resolveTypeAlias()
+        if (!resolvedType.toString().substringBefore("<").endsWith(KEY_MAP)) {
             logger.error(KtorfitError.PART_MAP_PARAMETER_TYPE_MUST_BE_MAP, ksValueParameter)
         }
         paramAnnos.add(it)

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/utils/Utils.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/utils/Utils.kt
@@ -2,11 +2,26 @@ package de.jensklingenberg.ktorfit.utils
 
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.squareup.kotlinpoet.FileSpec
 
+/**
+ * Recursively resolves typealias to its actual underlying type.
+ * For example: typealias StringMap = Map<String, String> -> Map<String, String>
+ */
+fun KSType.resolveTypeAlias(): KSType {
+    var currentType = this
+    while (currentType.declaration is KSTypeAlias) {
+        currentType = (currentType.declaration as KSTypeAlias).type.resolve()
+    }
+    return currentType
+}
+
 fun KSType?.resolveTypeName(): String {
-    // TODO: Find better way to handle type alias Types
-    return this.toString().removePrefix("[typealias ").removeSuffix("]")
+    if (this == null) return ""
+
+    // Resolve typealias to actual type and return its string representation
+    return this.resolveTypeAlias().toString()
 }
 
 fun String.prefixIfNotEmpty(s: String): String = (s + this).takeIf { this.isNotEmpty() } ?: this

--- a/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/TypeAliasTest.kt
+++ b/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/TypeAliasTest.kt
@@ -1,0 +1,231 @@
+package de.jensklingenberg.ktorfit
+
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspSourcesDir
+import de.jensklingenberg.ktorfit.model.KtorfitError
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class TypeAliasTest {
+    private val httpReqBuilderSource =
+        SourceFile.kotlin(
+            "ReqBuilder.kt",
+            """
+        package io.ktor.client.request
+
+interface HttpRequestBuilder
+        """,
+        )
+
+    @Test
+    fun whenHeaderMapUsesTypeAlias_ShouldWorkCorrectly() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.HeaderMap
+
+typealias StringMap = Map<String, String>
+
+interface TestService {
+    @GET("posts")
+    suspend fun test(@HeaderMap headers: StringMap): String
+}
+    """,
+            )
+
+        val expectedHeadersArgumentText = "headers.forEach{ append(it.key , \"\${it.value}\")"
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        assertTrue("Generated file should exist", generatedFile.exists())
+        val actualSource = generatedFile.readText()
+        assertTrue("Generated source should contain expected headers code", actualSource.contains(expectedHeadersArgumentText))
+    }
+
+    @Test
+    fun whenQueryMapUsesTypeAlias_ShouldWorkCorrectly() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.QueryMap
+
+typealias QueryParams = Map<String, String>
+
+interface TestService {
+    @GET("posts")
+    suspend fun test(@QueryMap params: QueryParams): String
+}
+    """,
+            )
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        // Test passes if file was generated without type validation errors
+        assertTrue("Generated file should exist - typealias was resolved correctly", generatedFile.exists())
+    }
+
+    @Test
+    fun whenFieldMapUsesTypeAlias_ShouldWorkCorrectly() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.FieldMap
+import de.jensklingenberg.ktorfit.http.FormUrlEncoded
+
+typealias FieldParams = Map<String, String>
+
+interface TestService {
+    @FormUrlEncoded
+    @POST("posts")
+    suspend fun test(@FieldMap fields: FieldParams): String
+}
+    """,
+            )
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        // Test passes if file was generated without type validation errors
+        assertTrue("Generated file should exist - typealias was resolved correctly", generatedFile.exists())
+    }
+
+    @Test
+    fun whenPartMapUsesTypeAlias_ShouldWorkCorrectly() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.PartMap
+import de.jensklingenberg.ktorfit.http.Multipart
+
+typealias Parts = Map<String, String>
+
+interface TestService {
+    @Multipart
+    @POST("upload")
+    suspend fun test(@PartMap parts: Parts): String
+}
+    """,
+            )
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        // Test passes if file was generated without type validation errors
+        assertTrue("Generated file should exist - typealias was resolved correctly", generatedFile.exists())
+    }
+
+    @Test
+    fun whenRequestBuilderUsesTypeAlias_ShouldWorkCorrectly() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.ReqBuilder
+import io.ktor.client.request.HttpRequestBuilder
+
+typealias RequestConfig = HttpRequestBuilder.() -> Unit
+
+interface TestService {
+    @GET("posts")
+    suspend fun test(@ReqBuilder builder: RequestConfig): String
+}
+    """,
+            )
+
+        val compilation = getCompilation(listOf(httpReqBuilderSource, source))
+        val result = compilation.compile()
+
+        // Compilation will fail due to missing Ktorfit imports, but KSP should not produce the type error
+        assertFalse(
+            "Should not contain HttpRequestBuilder type error for typealias",
+            result.messages.contains(KtorfitError.REQ_BUILDER_PARAMETER_TYPE_NEEDS_TO_BE_HTTP_REQUEST_BUILDER)
+        )
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        // Test passes if file was generated without type validation errors
+        assertTrue("Generated file should exist - typealias for HttpRequestBuilder was resolved correctly", generatedFile.exists())
+    }
+
+    @Test
+    fun whenNestedTypeAliasUsed_ShouldResolveToBaseType() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """package com.example.api
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.HeaderMap
+
+typealias StringStringMap = Map<String, String>
+typealias Headers = StringStringMap
+
+interface TestService {
+    @GET("posts")
+    suspend fun test(@HeaderMap headers: Headers): String
+}
+    """,
+            )
+
+        val expectedHeadersArgumentText = "headers.forEach{ append(it.key , \"\${it.value}\")"
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedSourcesDir = compilation.kspSourcesDir
+        val generatedFile =
+            File(
+                generatedSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+
+        assertTrue(generatedFile.exists())
+        val actualSource = generatedFile.readText()
+        assertTrue(actualSource.contains(expectedHeadersArgumentText))
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for Kotlin type aliases in the Ktorfit KSP processor, resolving the TODO comment in `Utils.kt` about finding a better way to handle typealias types.

## Changes

- Added `KSType.resolveTypeAlias()` function in `Utils.kt` that recursively unwraps typealiases to their underlying types
- Updated `KSType.resolveTypeName()` to use the new resolution function instead of string manipulation
- Updated type validation in `ParameterAnnotation.kt` to resolve typealiases before type checking for @HeaderMap, @QueryMap, @FieldMap, and @PartMap
- Added `TypeAliasTest.kt` with test cases for various annotation types with typealiases

## Example Usage

```kotlin
typealias Headers = Map<String, String>
typealias RequestConfig = HttpRequestBuilder.() -> Unit

interface TestService {
    @GET("posts")
    suspend fun getPosts(@HeaderMap headers: Headers): String
    
    @GET("user")
    suspend fun getUser(@ReqBuilder config: RequestConfig): String
}
```

## Testing

- `./gradlew :ktorfit-ksp:test` passes
- Added tests for typealiases with @HeaderMap, @QueryMap, @FieldMap, @PartMap, @ReqBuilder
- Added test for nested typealiases