### PR TITLE
Determine the default compiler plugin version from the Kotlin version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,14 +7,15 @@ Releasing
 2. Update **ktorfit** version inside `gradle/libs.versions.toml`
 3. Update **ktorfitGradlePlugin** version inside `gradle/libs.versions.toml`
 4. Update Compatibility table in Readme.md
-5. Update ktorfit release version in mkdocs.yml
-6. Update version in KtorfitGradleConfiguration
-7. Set the release date in docs/changelog.md
-8. `git commit -am "X.Y.Z."` (where X.Y.Z is the new version)
-9. Push and create a PR to the `master` branch
-10. When all checks successful, run GitHub Action `Publish Release` from your branch
-11. Set the Git tag `git tag -a X.Y.Z -m "X.Y.Z"` (where X.Y.Z is the new version)
-12. Merge the PR
-13. Create a new release with for the Tag on GitHub
-14. Run "deploy to GitHub pages" action
-15. Put the relevant changelog in the release description
+5. Update KtorfitCompilerSubPlugin.defaultCompilerPluginVersion if necessary 
+6. Update ktorfit release version in mkdocs.yml
+7. Update version in KtorfitGradleConfiguration
+8. Set the release date in docs/changelog.md
+9. `git commit -am "X.Y.Z."` (where X.Y.Z is the new version)
+10. Push and create a PR to the `master` branch
+11. When all checks successful, run GitHub Action `Publish Release` from your branch
+12. Set the Git tag `git tag -a X.Y.Z -m "X.Y.Z"` (where X.Y.Z is the new version)
+13. Merge the PR
+14. Create a new release with for the Tag on GitHub
+15. Run "deploy to GitHub pages" action
+16. Put the relevant changelog in the release description

--- a/ktorfit-gradle-plugin/api/ktorfit-gradle-plugin.api
+++ b/ktorfit-gradle-plugin/api/ktorfit-gradle-plugin.api
@@ -15,7 +15,6 @@ public final class de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin : org/g
 	public static final field GROUP_NAME Ljava/lang/String;
 	public static final field KTORFIT_COMPILER_PLUGIN_VERSION Ljava/lang/String;
 	public static final field KTORFIT_KSP_PLUGIN_VERSION Ljava/lang/String;
-	public static final field MIN_KOTLIN_VERSION Ljava/lang/String;
 	public static final field MIN_KSP_VERSION Ljava/lang/String;
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
@@ -23,6 +22,7 @@ public final class de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin : org/g
 }
 
 public final class de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin$Companion {
+	public final fun getMIN_KOTLIN_VERSION ()Lkotlin/KotlinVersion;
 }
 
 public class de/jensklingenberg/ktorfit/gradle/KtorfitPluginExtension {

--- a/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
+++ b/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
@@ -25,7 +25,7 @@ class KtorfitGradlePlugin : Plugin<Project> {
         const val KTORFIT_KSP_PLUGIN_VERSION = "2.7.1"
         const val KTORFIT_COMPILER_PLUGIN_VERSION = "2.3.2"
         const val MIN_KSP_VERSION = "2.0.2"
-        const val MIN_KOTLIN_VERSION = "2.2.0"
+        val MIN_KOTLIN_VERSION = KotlinVersion(2, 2, 0)
     }
 
     override fun apply(project: Project) {


### PR DESCRIPTION
### :thinking: DOD Checklist

- [x] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).

This will allow updating Kotlin without the overhead of having to select the corresponding compiler plugin version. It is still possible to override that if needed, since this just determines the default / fallback version.
