### PR TITLE
Only run cron for GitHub Actions on the main repo

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-gradle-wrapper:
-
+    if: github.repository == 'Foso/Ktorfit'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This cronjob runs (and fails) on all forks.
