### PR TITLE
Fix Renovate config to ignore Ktor EAP versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,10 +8,8 @@
   ],
   packageRules: [
     {
-      groupName: 'Ktor Client',
-      matchPackageNames: [
-        '/^io\\.ktor:ktor-client(-[^:]+)?$/',
-      ],
+      matchPackageNames: ['io.ktor:ktor-*'],
+      allowedVersions: '!/.*-eap-.*$/'
     },
   ],
 }


### PR DESCRIPTION
### :thinking: DOD Checklist

- [x] I did all relevant changes to the documentation and the [changelog](https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md).
