### PR TITLE
Remove Android-specific KSP dependency workaround and update ktorfit …

### DIFF
--- a/example/MultiplatformExample/shared/build.gradle.kts
+++ b/example/MultiplatformExample/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.android.library")
     id("com.google.devtools.ksp") version "2.3.4"
     id("kotlinx-serialization")
-    id("de.jensklingenberg.ktorfit") version "2.7.2"
+    id("de.jensklingenberg.ktorfit") version "2.7.3"
 }
 
 ktorfit {

--- a/example/MultiplatformExample/shared/build.gradle.kts
+++ b/example/MultiplatformExample/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.android.library")
     id("com.google.devtools.ksp") version "2.3.4"
     id("kotlinx-serialization")
-    id("de.jensklingenberg.ktorfit") version "2.7.2"
+    id("de.jensklingenberg.ktorfit") version "2.7.3are"
 }
 
 ktorfit {

--- a/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
+++ b/ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt
@@ -131,11 +131,6 @@ class KtorfitGradlePlugin : Plugin<Project> {
                             if (this.compilations.any { it.name == "test" }) {
                                 dependencies.add("ksp${capitalizedTargetName}Test", dependency)
                             }
-
-                            if (this.name == "android") {
-                                // Fix android as single target in multiplatform projects
-                                dependencies.add("ksp", dependency)
-                            }
                         }
 
                         kotlinExtension.sourceSets


### PR DESCRIPTION
## Summary

  Fixes #1030. Removes deprecated `ksp` configuration usage in KMP projects that triggered:

  > The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. Please use target-specific configurations like 'kspJvm' instead.

  ## Problem

  Inside `KtorfitGradlePlugin`'s `KotlinMultiplatformExtension` branch, the plugin added the KSP processor dependency twice for the android target:

  1. Via the target-specific config `kspAndroid` (correct, inside `targets.configureEach`)
  2. Via the legacy bare `"ksp"` config (deprecated in KMP)

  The second add was a workaround comment ("Fix android as single target in multiplatform projects") for an older KSP bug where `kspAndroid` was not registered
  automatically. Modern KSP (≥ `MIN_KSP_VERSION = 2.0.2`, already enforced by the plugin) registers `kspAndroid` correctly, so the fallback is obsolete and only produces
  warning noise in consumer builds.
  
  ## Change

  `ktorfit-gradle-plugin/src/main/java/de/jensklingenberg/ktorfit/gradle/KtorfitGradlePlugin.kt`: removed the `if (this.name == "android") { dependencies.add("ksp",
  dependency) }` block inside the KMP targets loop.

  The single-target path (`KotlinSingleTargetExtension` branch, line 110) is untouched — `"ksp"` is not deprecated there.

  ## Reference
  
  KSP multiplatform docs: https://kotlinlang.org/docs/ksp-multiplatform.html

  ## Test plan
  
  - [x] Publish plugin to mavenLocal and consume from `example/MultiplatformExample`
  - [x] Run `./gradlew :shared:help --warning-mode all` — deprecation warning no longer emitted
  - [x] CI green on all sample projects
  - [x] Verify generated KSP sources still produced under `build/generated/ksp/android/...` for KMP android target
  - [x] Smoke test android target build in `MultiplatformExample` end-to-end