### PR TITLE
Fix code generation for RequestType annotated lists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project orients towards [Semantic Versioning](http://semver.org/spec/v2
 Note: This project needs KSP to work and every new Ktorfit with an update of the KSP version is technically a breaking change.
 But there is no intent to bump the Ktorfit major version for every KSP update.
 
+# [TBD]()
+
+TBD
+========================================
+
+## Fixed
+- Fixed ksp generation for RequestType annotated Lists
+
 # [2.7.5]()
 
 2.7.5 - 2026-06-07

--- a/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/ParameterData.kt
+++ b/ktorfit-ksp/src/main/kotlin/de/jensklingenberg/ktorfit/model/ParameterData.kt
@@ -46,11 +46,18 @@ fun KSValueParameter.createParameterData(logger: KSPLogger): ParameterData {
         )
     }
 
+    val inspectionType =
+        parameterAnnotations
+            .filterIsInstance<ParameterAnnotation.RequestType>()
+            .firstOrNull()
+            ?.requestType
+            ?: parameterType
+
     val name = if (hasRequestBuilderAnno) "HttpRequestBuilder.()->Unit" else parameterType.resolveTypeName()
     val type =
         ReturnTypeData(
             name,
-            parameterType,
+            inspectionType,
             findTypeName(parameterType, ksValueParameter.containingFile!!.filePath)
         )
 

--- a/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/RequestTypeTest.kt
+++ b/ktorfit-ksp/src/test/kotlin/de/jensklingenberg/ktorfit/RequestTypeTest.kt
@@ -1,6 +1,7 @@
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspSourcesDir
 import de.jensklingenberg.ktorfit.getCompilation
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -36,5 +37,37 @@ interface TestService {
             )
         val actualSource = generatedFile.readText()
         assertTrue(actualSource.contains(expectedFunctionSource))
+    }
+
+    @Test
+    fun `should generate code based on mapped type for List`() {
+        val source =
+            SourceFile.kotlin(
+                "Source.kt",
+                """
+      package com.example.api
+import de.jensklingenberg.ktorfit.http.*
+
+interface TestService {
+    @GET("posts")
+    suspend fun test(@RequestType(String::class) @Query("ids") ids: List<Int>): String
+}
+    """,
+            )
+
+        val expectedFunctionSource = $$"""ids?.let{ parameter("ids", "$it") }"""
+
+        val compilation = getCompilation(listOf(source))
+        compilation.compile()
+
+        val generatedFile =
+            File(
+                compilation.kspSourcesDir,
+                "/kotlin/com/example/api/_TestServiceImpl.kt",
+            )
+        val actualSource = generatedFile.readText()
+
+        assertTrue(actualSource.contains(expectedFunctionSource))
+        assertFalse(actualSource.contains("ids?.filterNotNull()?.forEach"))
     }
 }

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -92,7 +92,7 @@ kotlin {
 
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute(module("de.jensklingenberg.ktorfit:ksp"))
+        substitute(module("de.jensklingenberg.ktorfit:ktorfit-ksp"))
             .using(project(":ktorfit-ksp"))
             .because("we work with the unreleased development version")
         substitute(module("de.jensklingenberg.ktorfit:gradle-plugin"))

--- a/sandbox/src/commonMain/kotlin/com/example/api/JsonPlaceHolderApi.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/api/JsonPlaceHolderApi.kt
@@ -7,6 +7,7 @@ import de.jensklingenberg.ktorfit.Call
 import de.jensklingenberg.ktorfit.http.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import de.jensklingenberg.ktorfit.http.Query
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.Flow
 
@@ -53,6 +54,12 @@ interface JsonPlaceHolderApi {
     @GET("posts/{postId}/comments")
     suspend fun getCommentsByPostIdResponse(
         @RequestType(Int::class) @Path("postId") postId: String
+    ): MyOwnResponse<List<Comment>>
+
+    @GET("posts/{postId}/comments")
+    suspend fun getCommentsByPostIdResponse(
+        @Path("postId") postId: String,
+        @Query("commentTypes") @RequestType(String::class) commentTypes: List<String>
     ): MyOwnResponse<List<Comment>>
 
     @Headers(value = ["Content-Type: application/json"])

--- a/sandbox/src/commonMain/kotlin/com/example/model/ArrayToStringConverterFactory.kt
+++ b/sandbox/src/commonMain/kotlin/com/example/model/ArrayToStringConverterFactory.kt
@@ -1,0 +1,30 @@
+package com.example.model
+
+import de.jensklingenberg.ktorfit.converter.Converter
+import kotlin.reflect.KClass
+
+class ArrayToStringConverterFactory : Converter.Factory {
+    private fun supportedType(
+        data: Any,
+        requestType: KClass<*>
+    ): Boolean {
+        val parameterIsList = List::class.isInstance(data)
+        val requestIsString = requestType == String::class
+        return parameterIsList && requestIsString
+    }
+
+    override fun requestParameterConverter(
+        parameterType: KClass<*>,
+        requestType: KClass<*>
+    ): Converter.RequestParameterConverter {
+        return object : Converter.RequestParameterConverter {
+            override fun convert(data: Any): Any {
+                return if (supportedType(data, requestType)) {
+                    (data as? List<*>)?.joinToString(",")!!
+                } else {
+                    data
+                }
+            }
+        }
+    }
+}

--- a/sandbox/src/jvmMain/kotlin/de/jensklingenberg/ktorfit/demo/JvMMain.kt
+++ b/sandbox/src/jvmMain/kotlin/de/jensklingenberg/ktorfit/demo/JvMMain.kt
@@ -2,6 +2,7 @@ package de.jensklingenberg.ktorfit.demo
 
 import com.example.UserFactory
 import com.example.api.JsonPlaceHolderApi
+import com.example.model.ArrayToStringConverterFactory
 import com.example.model.ExampleApi
 import com.example.model.MyOwnResponse
 import com.example.model.MyOwnResponseConverterFactory
@@ -42,6 +43,10 @@ val jvmKtorfit =
     ktorfit {
         baseUrl(JsonPlaceHolderApi.baseUrl)
         httpClient(jvmClient)
+
+        converterFactories(
+            ArrayToStringConverterFactory()
+        )
     }
 
 val userKtorfit =


### PR DESCRIPTION
### Problem

Using a `@RequestType` annotation on List/Array parameters was not supported properly as the generated code treat the parameter builder as iterable, no matter what the type was actually mapped to. So for example the following code would previously cause ksp to generate non-compiling code:

```kotlin
interface MyDataSource {
    @GET
    suspend fun getData(
        @Url url: String,
        @Query("someFilterData") @RequestType(String::class) someFilterData: List<Filters>
    ): MyResponse
}
```

In this case the backend is supposed to work with a comma separated and html-encoded value for `someFilterData`. A converter factory should take care of that.

However, currently the generated code produces the following line
```kotlin
someFilterData?.filterNotNull()?.forEach { parameter("someFilterData", "$it") }
```
which does not compile, as the parameter is already expected to be a String at this point.

### Change

The proposed change now no longer relies on the initial datatype to determine how the parameters are added to the request. Instead the actual mapped type causes the code generation to decide which approach is the correct one.

Also added an Example implementation of the stated ConverterFactory to the demo project