### PR TITLE
Release 2.7.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,16 +7,23 @@ and this project orients towards [Semantic Versioning](http://semver.org/spec/v2
 Note: This project needs KSP to work and every new Ktorfit with an update of the KSP version is technically a breaking change.
 But there is no intent to bump the Ktorfit major version for every KSP update.
 
-# [TBD]()
+# [2.7.4]()
 
-TBD
+2.7.4 - 2026-06-03
 ========================================
 * Supported KSP version: >=2.0.2
 * Supported Kotlin version: >=2.2.0
 * Ktor version: 3.5.0
 
 ## Changed
+- Update Kotlin to 2.4.0
+- Update KSP to 2.3.9
 - Update Ktor to 3.5.0
+
+## Fixed
+- The compilerPluginVersion will now get correctly set to 2.3.5 by the Gradle plugin to support using Kotlin 2.4.0+.
+
+Thanks to @eygraber for contributing to this release!
 
 # [2.7.3]()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ inspired by [Retrofit](https://square.github.io/retrofit/)
 
 | Ktorfit-version                                                               | 
 |-------------------------------------------------------------------------------|
+| **_2.7.4_** https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md#274 |
 | **_2.7.2_** https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md#272 |
 | **_2.6.0_** https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md#260 |
 | **_2.5.0_** https://github.com/Foso/Ktorfit/blob/master/docs/CHANGELOG.md#250 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlinPoet = "2.3.0"
 kspVersion = "2.3.9"
 
 # these are the release versions for the artifacts, not for libraries in the catalog
-ktorfit = "2.7.3"
+ktorfit = "2.7.4"
 ktorfitCompiler = "2.3.5"
 
 ktorfitGradlePlugin = "2.7.2"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,9 +13,9 @@ extra:
   site:
     images: '../../images'
   ktorfit:
-    release: "2.7.3"
+    release: "2.7.4"
   ktor:
-    release: "3.4.1"
+    release: "3.5.0"
   social:
     - icon: fontawesome/brands/github-alt
       link: 'https://github.com/foso'


### PR DESCRIPTION
Release **2.7.4**.

## Version changes (`gradle/libs.versions.toml`)
- `ktorfit` 2.7.3 → **2.7.4**
- `ktorfitCompiler` already at **2.3.5** (built against Kotlin 2.4.0)

## Docs
- `mkdocs.yml`: ktorfit release → 2.7.4, ktor release → 3.5.0
- `docs/index.md`: added 2.7.4 to the compatibility table
- `docs/CHANGELOG.md`: dated 2.7.4 section (2026-06-03)

## Included since 2.7.3
- Update Kotlin to 2.4.0
- Update KSP to 2.3.9
- Update Ktor to 3.5.0
- `compilerPluginVersion` now resolves to 2.3.5 for Kotlin 2.4.0+ (2.3.x projects stay on 2.3.4)

`KtorfitCompilerSubPlugin.defaultCompilerPluginVersion` (RELEASING.md step 4) was already updated on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)