### PR TITLE
2.7.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlinPoet = "2.3.0"
 kspVersion = "2.3.9"
 
 # these are the release versions for the artifacts, not for libraries in the catalog
-ktorfit = "2.7.4"
+ktorfit = "2.7.5"
 ktorfitCompiler = "2.3.5"
 
 ktorfitGradlePlugin = "2.7.2"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ extra:
   site:
     images: '../../images'
   ktorfit:
-    release: "2.7.4"
+    release: "2.7.5"
   ktor:
     release: "3.5.0"
   social:


### PR DESCRIPTION
Release 2.7.5

Bumps the `ktorfit` artifact version to 2.7.5 (`ktorfitCompiler` stays at 2.3.5) and the docs release version in `mkdocs.yml`. The changelog entry and source fix were already merged in #1081.

## Changed
- `compilerPluginVersion` won't have a default value set; if a value isn't present, the version to use will be inferred from the project's version of Kotlin

## Fixed
- The compilerPluginVersion will now get correctly set to 2.3.5 by the Gradle plugin to support using Kotlin 2.4.0+.